### PR TITLE
Trees: categorical validation & missing values

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -291,12 +291,6 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             # because it is assumed X is fully numeric by then. Thus, missing value mask
             # need to be checked separately.
             #
-            # TODO: we can support missing values with categories by either:
-            # 1. sending them down randomly through the tree (no assumptions)
-            # 2. sending them down to missing_goes_to_left according to child with
-            # most samples (assumes missing at random, where missingness correlates
-            # with most prevalent observed samples).
-            # To align this with HGBT, we would do #2.
             missing_values_in_feature_mask = (
                 self._compute_missing_values_in_feature_mask(X)
             )
@@ -490,10 +484,6 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             for idx, categories in zip(
                 np.flatnonzero(is_categorical_), self._categorical_encoder.categories_
             ):
-                # OrdinalEncoder places np.nan last if missing values reach fit.
-                if len(categories) and is_scalar_nan(categories[-1]):
-                    categories = categories[:-1]
-
                 n_categories = categories.size
                 self.n_categories_in_feature_[idx] = n_categories
 
@@ -580,29 +570,6 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
         return self
 
-    def _check_categorical_missing(self, X):
-        """Reject scalar NaN values in categorical features.
-
-        ``X`` is converted to an object array so mixed string/object
-        categorical data can be scanned before ordinal encoding. This check
-        uses :func:`~sklearn.utils._missing.is_scalar_nan`, and therefore only
-        detects scalar NaN values such as ``np.nan`` and ``float("nan")``.
-
-        It does not call pandas or Polars missing-value APIs, so plain
-        ``pd.NA``, ``None``, or Polars nulls are not detected here if they
-        materialize as non-NaN Python objects. Missing values from pandas
-        categorical columns are still rejected when they materialize as
-        ``np.nan``.
-        """
-        X = np.asarray(X, dtype=object)
-        missing_mask = np.fromiter(
-            (is_scalar_nan(x) for x in X.ravel()),
-            dtype=bool,
-            count=X.size,
-        )
-        if np.any(missing_mask):
-            raise ValueError("Missing values are not supported in categorical features")
-
     def _fit_categorical_features(self, X):
         """Fit the categorical feature encoder on selected columns.
 
@@ -610,9 +577,6 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         dtypes and string/object values are preserved until encoding.
         """
         X_categorical = _safe_indexing(X, self.is_categorical_, axis=1)
-        self._check_categorical_missing(X_categorical)
-        # TODO: HGBT encodes missing values as np.nan, which we can support
-        #   but would need to add missing categorical values support
         self._categorical_encoder = OrdinalEncoder(
             dtype=np.float32,  # trees require X to be float32
             categories="auto",
@@ -621,23 +585,28 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             encoded_missing_value=np.nan,
         )
         self._categorical_encoder.fit(X_categorical)
+        self._categorical_missing_codes = np.array(
+            [
+                len(categories) - 1
+                if len(categories) and is_scalar_nan(categories[-1])
+                else np.nan
+                for categories in self._categorical_encoder.categories_
+            ],
+            dtype=np.float32,
+        )
 
     def _transform_categorical_features(self, X):
         if not hasattr(X, "shape"):
             X = np.asarray(X, dtype=object)
         X_categorical = _safe_indexing(X, self.is_categorical_, axis=1)
-        self._check_categorical_missing(X_categorical)
         X_categorical = self._categorical_encoder.transform(X_categorical)
-        unknown_mask = X_categorical == -1
-        if np.any(unknown_mask):
-            categorical_indices = np.flatnonzero(self.is_categorical_)
-            feature_idx = categorical_indices[
-                np.flatnonzero(unknown_mask.any(axis=0))[0]
-            ]
-            raise ValueError(
-                "Found unknown categories in categorical feature "
-                f"{feature_idx} during transform."
+
+        for feature_idx, missing_code in enumerate(self._categorical_missing_codes):
+            missing_or_unknown = (X_categorical[:, feature_idx] == -1) | np.isnan(
+                X_categorical[:, feature_idx]
             )
+            if np.any(missing_or_unknown):
+                X_categorical[missing_or_unknown, feature_idx] = missing_code
 
         # replace features with the encoded categorical values
         X_out = np.empty(X.shape, dtype=np.float32)
@@ -1071,8 +1040,8 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         Categorical features are only supported for dense inputs
         and single-output targets.
         Values of categorical features are encoded internally. Each categorical
-        feature can have at most 256 categories and missing values are not
-        supported.
+        feature can have at most 256 categories, including missing values when
+        present. Unknown categories at predict time are treated as missing values.
         Categorical features cannot have non-zero monotonic constraint.
 
         When these constraints are not met, ``fit`` will raise an error.
@@ -1493,8 +1462,8 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
         Categorical features are only supported for dense inputs
         and single-output targets.
         Values of categorical features are encoded internally. Each categorical
-        feature can have at most 256 categories and missing values are not
-        supported.
+        feature can have at most 256 categories, including missing values when
+        present. Unknown categories at predict time are treated as missing values.
         Categorical features cannot have non-zero monotonic constraints.
 
         When these constraints are not met, ``fit`` will raise an error.
@@ -1883,8 +1852,8 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
         Categorical features are only supported for dense inputs
         and single-output targets.
         Values of categorical features are encoded internally. Each categorical
-        feature can have at most 256 categories and missing values are not
-        supported.
+        feature can have at most 256 categories, including missing values when
+        present. Unknown categories at predict time are treated as missing values.
         Categorical features cannot have non-zero monotonic constraints.
 
         When these constraints are not met, ``fit`` will raise an error.
@@ -2178,8 +2147,8 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
         Categorical features are only supported for dense inputs
         and single-output targets.
         Values of categorical features are encoded internally. Each categorical
-        feature can have at most 256 categories and missing values are not
-        supported.
+        feature can have at most 256 categories, including missing values when
+        present. Unknown categories at predict time are treated as missing values.
         Categorical features cannot have non-zero monotonic constraints.
 
         When these constraints are not met, ``fit`` will raise an error.

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -52,7 +52,6 @@ from sklearn.utils.validation import (
     _check_n_features,
     _check_sample_weight,
     assert_all_finite,
-    check_array,
     check_is_fitted,
     validate_data,
 )
@@ -248,6 +247,12 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         self.is_categorical_ = is_categorical_
         has_categorical = is_categorical_ is not None
 
+        if has_categorical and not check_input:
+            raise NotImplementedError(
+                "Skipping input checking is not implemented "
+                "when categorical values are present."
+            )
+
         if check_input:
             if issparse(X) and has_categorical:
                 raise NotImplementedError(
@@ -264,29 +269,23 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                 dtype=np.float32, accept_sparse="csc", ensure_all_finite=False
             )
             check_y_params = dict(ensure_2d=False, dtype=None)
+            reset = True
             if has_categorical:
-                validate_data(self, X, reset=True, skip_check_array=True)
+                validate_data(self, X, skip_check_array=True)
+                self._fit_categorical_features(X)
+                X = self._transform_categorical_features(X)
+                reset = False
             else:
-                X, y = validate_data(
-                    self, X, y, validate_separately=(check_X_params, check_y_params)
-                )
+                self._categorical_encoder = None
 
-        if has_categorical:
-            # Categorical feature selection must see the original container for
-            # names/dtypes, but tree fitting needs numeric values. Encode selected
-            # columns before the final numeric validation, preserving column order.
-            self._fit_categorical_features(X)
-            X = self._transform_categorical_features(X)
-            if check_input:
-                X = check_array(X, input_name="X", estimator=self, **check_X_params)
-                _check_n_features(self, X, reset=False)
-                y = check_array(y, input_name="y", estimator=self, **check_y_params)
-            else:
-                X = np.asarray(X, dtype=np.float32)
-        else:
-            self._categorical_encoder = None
+            X, y = validate_data(
+                self,
+                X,
+                y,
+                validate_separately=(check_X_params, check_y_params),
+                reset=reset,
+            )
 
-        if check_input:
             # Note: we must check missing after the categorical features
             # because it is assumed X is fully numeric by then. Thus, missing value mask
             # need to be checked separately.
@@ -635,38 +634,27 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                     )
                 validate_data(self, X, reset=False, skip_check_array=True)
                 X = self._transform_categorical_features(X)
-                X = check_array(
-                    X,
-                    input_name="X",
-                    estimator=self,
-                    dtype=np.float32,
-                    accept_sparse="csr",
-                    ensure_all_finite=ensure_all_finite,
-                )
-                _check_n_features(self, X, reset=False)
-            else:
-                X = validate_data(
-                    self,
-                    X,
-                    dtype=np.float32,
-                    accept_sparse="csr",
-                    reset=False,
-                    ensure_all_finite=ensure_all_finite,
-                )
+
+            X = validate_data(
+                self,
+                X,
+                dtype=np.float32,
+                accept_sparse="csr",
+                reset=False,
+                ensure_all_finite=ensure_all_finite,
+            )
             if issparse(X) and (
                 X.indices.dtype != np.intc or X.indptr.dtype != np.intc
             ):
                 raise ValueError("No support for np.int64 index based sparse matrices")
         else:
+            if has_categorical:
+                raise NotImplementedError(
+                    "Skipping input checking is not implemented "
+                    "when categorical values are present."
+                )
             # The number of features is checked regardless of `check_input`
             _check_n_features(self, X, reset=False)
-            if has_categorical:
-                if issparse(X):
-                    raise NotImplementedError(
-                        "Categorical features not supported with sparse inputs"
-                    )
-                X = self._transform_categorical_features(X)
-                X = np.asarray(X, dtype=np.float32)
         return X
 
     def predict(self, X, check_input=True):

--- a/sklearn/tree/_partitioner.pxd
+++ b/sklearn/tree/_partitioner.pxd
@@ -82,7 +82,6 @@ cdef class DensePartitioner:
     # memoryview of the n_categories in every feature
     cdef const intp_t[::1] n_categories_in_feature
     cdef intp_t n_categories  # keep track of n_categories in current split
-    cdef intp_t n_words
 
     # purely for Breiman shortcut
     cdef intp_t[::1] counts
@@ -157,7 +156,6 @@ cdef class SparsePartitioner:
     # memoryview of the n_categories in every feature
     cdef const intp_t[::1] n_categories_in_feature
     cdef intp_t n_categories  # keep track of n_categories in current split
-    cdef intp_t n_words
 
     # purely for Breiman shortcut
     cdef intp_t[::1] counts

--- a/sklearn/tree/_partitioner.pyx
+++ b/sklearn/tree/_partitioner.pyx
@@ -62,7 +62,6 @@ cdef class DensePartitioner:
 
         self.n_categories_in_feature = n_categories_in_feature
         self.n_categories = 0
-        self.n_words = -1
 
         # for breiman shortcut:
         self.counts = np.empty(MAX_NUM_CATEGORIES, dtype=np.intp)
@@ -136,10 +135,6 @@ cdef class DensePartitioner:
 
         self.n_missing = n_missing
         self.n_categories = self.n_categories_in_feature[current_feature]
-        if self.n_categories > 0:
-            self.n_words = (self.n_categories + 31) >> 5   # divide by 32 with ceil
-        else:
-            self.n_words = 0
 
         if n_missing == self.end - self.start:
             # if all the values at this point are missing, the values are sorted by default
@@ -472,7 +467,6 @@ cdef class DensePartitioner:
                 self.n_categories,
                 &self.counts[0],
                 split.left_cat_bitset,
-                self.n_words
             )
             return split
 
@@ -1016,7 +1010,6 @@ cdef inline void split_pos_to_bitset_words(
     intp_t n_sorted,
     const intp_t* counts,
     BITSET_DTYPE_C out_words,
-    intp_t n_words
 ) noexcept nogil:
     """Build a categorical-split bitset from a prefix of sorted categories.
 
@@ -1040,15 +1033,6 @@ cdef inline void split_pos_to_bitset_words(
     out_words : BITSET_DTYPE_C
         Output buffer of 32-bit words; zeroed and filled by
         this function.
-    n_words : intp_t
-        Length of `out_words`.  Must satisfy
-        ``n_words >= ceil((max_category_id + 1) / 32)``.
-
-    Notes
-    -----
-    Caller must guarantee that every id in `sorted_cat` satisfies
-    ``0 <= id < 32 * n_words``.  No bounds checking is performed.
-    This function is ``nogil`` and performs no allocation.
     """
     cdef intp_t r, c
     cdef intp_t offset = 0

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -3204,18 +3204,15 @@ def test_no_sparse_with_categorical(name):
 
 @pytest.mark.parametrize("Tree", [DecisionTreeClassifier, DecisionTreeRegressor])
 @pytest.mark.parametrize(
-    "X_test, match",
+    "X_test",
     [
-        (np.array([[2.0]], dtype=np.float64), "Found unknown categories"),
-        (np.array([[0.5]], dtype=np.float64), "Found unknown categories"),
-        (np.array([[-1.0]], dtype=np.float64), "Found unknown categories"),
-        (
-            np.array([[np.nan]], dtype=np.float64),
-            "Missing values are not supported in categorical features",
-        ),
+        np.array([[2.0]], dtype=np.float64),
+        np.array([[0.5]], dtype=np.float64),
+        np.array([[-1.0]], dtype=np.float64),
+        np.array([[np.nan]], dtype=np.float64),
     ],
 )
-def test_predict_invalid_categorical_values(Tree, X_test, match):
+def test_predict_unknown_categorical_values_as_missing(Tree, X_test):
     X = np.array([[0.0], [1.0], [0.0], [1.0]], dtype=np.float64)
     if Tree is DecisionTreeClassifier:
         y = np.array([0, 1, 0, 1])
@@ -3223,8 +3220,7 @@ def test_predict_invalid_categorical_values(Tree, X_test, match):
         y = np.array([0.0, 1.0, 0.0, 1.0])
 
     est = Tree(categorical_features=[0], random_state=0).fit(X, y)
-    with pytest.raises(ValueError, match=match):
-        est.predict(X_test)
+    assert_array_equal(est.predict(X_test), [1])
 
 
 @pytest.mark.parametrize("Tree", [DecisionTreeClassifier, DecisionTreeRegressor])
@@ -3282,13 +3278,17 @@ def test_fit_categorical_too_many_categories(Tree):
 
 @pytest.mark.parametrize("Tree", [DecisionTreeClassifier, DecisionTreeRegressor])
 def test_fit_categorical_missing_values(Tree):
-    X = np.array([["a"], [np.nan], ["b"], ["b"]], dtype=object)
-    y = np.array([0, 1, 0, 1])
+    X = np.array([[np.nan]] * 4 + [["a"]] * 4 + [["b"]] * 4, dtype=object)
+    if Tree is DecisionTreeClassifier:
+        y = np.array([0] * 4 + [1] * 8)
+    else:
+        y = np.array([0.0] * 4 + [1.0] * 8)
 
-    with pytest.raises(
-        ValueError, match="Missing values are not supported in categorical features"
-    ):
-        Tree(categorical_features=[0], random_state=0).fit(X, y)
+    est = Tree(categorical_features=[0], random_state=0).fit(X, y)
+
+    assert_array_equal(est.n_categories_in_feature_, [3])
+    X_test = np.array([[np.nan], ["a"], ["b"], ["c"]], dtype=object)
+    assert_array_equal(est.predict(X_test), [0, 1, 1, 0])
 
 
 @pytest.mark.parametrize("Tree", [DecisionTreeClassifier, DecisionTreeRegressor])
@@ -3297,8 +3297,7 @@ def test_predict_unknown_string_category(Tree):
     y = np.array([0, 1, 0, 1])
     est = Tree(categorical_features=[0], random_state=0).fit(X, y)
 
-    with pytest.raises(ValueError, match="Found unknown categories"):
-        est.predict(np.array([["c"]], dtype=object))
+    assert_array_equal(est.predict(np.array([["c"]], dtype=object)), [1])
 
 
 @pytest.mark.parametrize("Tree", [DecisionTreeClassifier, DecisionTreeRegressor])

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -3189,7 +3189,8 @@ def test_no_sparse_with_categorical(name):
         Tree(categorical_features=[3, 4]).fit(X, y).predict(X_sparse)
 
     with pytest.raises(
-        NotImplementedError, match="Categorical features not supported with sparse"
+        NotImplementedError,
+        match="Skipping input checking is not implemented",
     ):
         Tree(categorical_features=[3, 4]).fit(X, y).predict(X_sparse, check_input=False)
 
@@ -3307,7 +3308,6 @@ def test_predict_categorical_list_input(Tree):
     est = Tree(categorical_features=[0], random_state=0).fit(X, y)
 
     assert_array_equal(est.predict([["a"], ["b"]]), y[:2])
-    assert_array_equal(est.predict([["a"], ["b"]], check_input=False), y[:2])
 
 
 @pytest.mark.parametrize("Tree", [DecisionTreeClassifier, DecisionTreeRegressor])


### PR DESCRIPTION
Some suggestions that are easier made this way than via the suggestion comments in github.

It aligns the support of missing values with what is done in HGB. 

And reduces the number of lines.